### PR TITLE
force tests to use separate database

### DIFF
--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,4 +1,5 @@
 import pyrebase
+import os
 
 config = {
   'apiKey': "AIzaSyAQjigaQ9FS1UlSAeGwZmIkoWnv0AnqvEU",
@@ -10,5 +11,10 @@ config = {
   'appId': "1:506242405702:web:2e9349c19e3ed314704147",
   'measurementId': "G-5LBEP5LQTH"
 }
+
+if os.environ.get('CI') == 'true':
+  config['databaseURL'] = config['databaseURL'] + '/CI-rtdb'
+  print('CI environment detected!')
+  print(f'Using CI database at {config["databaseURL"]} for testing.')
 
 firebase = pyrebase.initialize_app(config)

--- a/backend/test/Test.py
+++ b/backend/test/Test.py
@@ -4,6 +4,11 @@ from AuthTest import AuthTestApp
 from DeckTest import DeckTestApp
 from CardTest import CardTestApp
 import unittest
+import os
 
 if __name__=="__main__":
+  
+  if os.environ.get('CI') != 'true':
+    raise Exception('ERROR: set environment variable CI=true to run tests')
+
   unittest.main()


### PR DESCRIPTION
Forces tests to use a separate database, resolves #28 .

Tests should be run, from now on, as follows:

```
CI=true coverage run -m backend.test.Test
```